### PR TITLE
Feature/persistent settings demo

### DIFF
--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: ⚙️ Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 10.0.x
 
       - name: 🔨 Build the MSI
         run: ./msi/build.ps1

--- a/msi/Package.wxs
+++ b/msi/Package.wxs
@@ -2,7 +2,8 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-    xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+    xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+    xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
     <Package Name="$(env.PRODUCT_NAME)"
         Manufacturer="$(env.COMPANY_NAME)"
@@ -37,6 +38,7 @@
             AllowAbsent="no">
 
             <ComponentGroupRef Id="HarvestedComponents"/>
+            <ComponentRef Id="AppDataFolder" />
 
             <Feature Id="StartMenuFolderFeature"
                 Title="Start Menu Folder"
@@ -99,6 +101,33 @@
                         Type="integer"
                         Value="1"
                         KeyPath="yes" />
+                </Component>
+            </Directory>
+        </StandardDirectory>
+
+        <Property Id="APPDATAPRODUCTFOLDER">
+            <RegistrySearch Root="HKCU"
+                Key="Software\WSL USB Manager\WSL USB Manager"
+                Name="AppDataPath"
+                Type="raw" />
+        </Property>
+
+        <StandardDirectory Id="LocalAppDataFolder">
+            <Directory Id="AppDataProductFolder"
+                Name="WSL USB Manager">
+                <Component Id="AppDataFolder"
+                    Guid="24f9c311-7518-48d1-ade8-f1a98fd8f40e">
+                    <CreateFolder />
+                    <RemoveFolder Id="AppDataProductFolder"
+                        On="uninstall" />
+                    <RegistryValue Root="HKCU"
+                        Key="Software\WSL USB Manager\WSL USB Manager"
+                        Name="AppDataPath"
+                        Type="string"
+                        Value="[AppDataProductFolder]"
+                        KeyPath="yes" />
+                    <util:RemoveFolderEx On="uninstall"
+                        Property="APPDATAPRODUCTFOLDER" />
                 </Component>
             </Directory>
         </StandardDirectory>

--- a/msi/Package.wxs
+++ b/msi/Package.wxs
@@ -107,7 +107,7 @@
 
         <Property Id="APPDATAPRODUCTFOLDER">
             <RegistrySearch Root="HKCU"
-                Key="Software\WSL USB Manager\WSL USB Manager"
+                Key="Software\[Manufacturer]\[ProductName]"
                 Name="AppDataPath"
                 Type="raw" />
         </Property>
@@ -121,7 +121,7 @@
                     <RemoveFolder Id="AppDataProductFolder"
                         On="uninstall" />
                     <RegistryValue Root="HKCU"
-                        Key="Software\WSL USB Manager\WSL USB Manager"
+                        Key="Software\[Manufacturer]\[ProductName]"
                         Name="AppDataPath"
                         Type="string"
                         Value="[AppDataProductFolder]"

--- a/msi/README.md
+++ b/msi/README.md
@@ -5,3 +5,8 @@ From the root of the repository, run the build script:
 ```powershell
 ./msi/build.ps1
 ```
+
+## Dependencies
+
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download)
+

--- a/msi/build.ps1
+++ b/msi/build.ps1
@@ -11,7 +11,7 @@ dotnet clean msi
 New-Item -ItemType Directory -Path msi/staging -Force
 
 # Copy the files to the staging directory
-Copy-Item target/release/wsl-usb-manager.exe msi/staging/wsl-usb-manager.exe
+Copy-Item target/x86_64-pc-windows-msvc/release/wsl-usb-manager.exe msi/staging/wsl-usb-manager.exe
 Copy-Item LICENSE.md msi/staging/LICENSE.md
 
 # Run a dotnet build with some environment variables set

--- a/msi/wsl-usb-manager.wixproj
+++ b/msi/wsl-usb-manager.wixproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="WixToolset.Heat" Version="5.0.2" />
         <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
+        <PackageReference Include="WixToolset.Util.wixext" Version="5.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/gui/gui.rs
+++ b/src/gui/gui.rs
@@ -73,6 +73,15 @@ pub fn show_usbipd_untested_version_warning() {
     });
 }
 
+pub fn show_settings_error(error: &str) {
+    nwg::message(&nwg::MessageParams {
+        title: "WSL USB Manager: Settings Error",
+        content: &format!("Failed to initialize the application settings.\n\nError:\n{error}"),
+        buttons: nwg::MessageButtons::Ok,
+        icons: nwg::MessageIcons::Error,
+    });
+}
+
 /// Shows an error message telling the user that the app failed to start.
 /// The passed message should contain details about the error that occurred.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod args;
 mod auto_attach;
 mod gui;
+mod settings;
 mod usbipd;
 mod win_utils;
 
@@ -18,6 +19,8 @@ fn main() -> ExitCode {
         Ok(args) => args,
         Err(code) => return code,
     };
+
+    let _settings_location = settings::ensure_settings_dir();
 
     // Ensure that only one instance of the application is running
     if !win_utils::acquire_single_instance_lock() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ fn main() -> ExitCode {
         Err(code) => return code,
     };
 
-    let _settings_location = settings::ensure_settings_dir();
+    let _ = settings::ensure_settings_dir()
+        .and_then(|path| settings::write_persistent_example(&path))
+        .map_err(|err| gui::show_settings_error(&err.to_string()));
 
     // Ensure that only one instance of the application is running
     if !win_utils::acquire_single_instance_lock() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+pub fn ensure_settings_dir() -> PathBuf {
+    let path = std::env::var("LOCALAPPDATA")
+        .map(|dir| PathBuf::from(dir).join("WSL USB Manager"))
+        .expect("LOCALAPPDATA environment variable must be set");
+
+    let _ = std::fs::create_dir_all(&path);
+    write_persistent_example(&path);
+    path
+}
+
+/// Temporary example of saving some data.
+fn write_persistent_example(dir: &Path) {
+    use std::time::SystemTime;
+
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_default();
+    let _ = std::fs::write(dir.join("persistent_example.txt"), timestamp);
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,22 +1,23 @@
+use std::io;
 use std::path::{Path, PathBuf};
 
-pub fn ensure_settings_dir() -> PathBuf {
+/// Temporary function that creates the folder and does an easy example.
+pub fn ensure_settings_dir() -> Result<PathBuf, io::Error> {
     let path = std::env::var("LOCALAPPDATA")
         .map(|dir| PathBuf::from(dir).join("WSL USB Manager"))
-        .expect("LOCALAPPDATA environment variable must be set");
+        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))?;
 
-    let _ = std::fs::create_dir_all(&path);
-    write_persistent_example(&path);
-    path
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
 }
 
 /// Temporary example of saving some data.
-fn write_persistent_example(dir: &Path) {
+pub fn write_persistent_example(dir: &Path) -> Result<(), io::Error> {
     use std::time::SystemTime;
 
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs().to_string())
         .unwrap_or_default();
-    let _ = std::fs::write(dir.join("persistent_example.txt"), timestamp);
+    std::fs::write(dir.join("persistent_example.txt"), timestamp)
 }


### PR DESCRIPTION
Somewhat trivial example of creating and writing to the local app data folder. Turns out we can use the `LOCALAPPDATA` environment variable which is guaranteed to be present on windows systems (source: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-doenvironmentsubsta#remarks), so this should actually work for the portable as well! The MSI gets us uninstall cleanup of that folder.

To test: 

- install from MSI and run, or run portable
- run app
- `cat "$env:LOCALAPPDATA\WSL USB Manager\persistent_example.txt"`
- restart app
- `cat "$env:LOCALAPPDATA\WSL USB Manager\persistent_example.txt"`
- observe timestamps from the example

```
PS C:\Users\jp\repos\wsl-usb-manager> cat "$env:LOCALAPPDATA\WSL USB Manager\persistent_example.txt"
1771723766
PS C:\Users\jp\repos\wsl-usb-manager> cat "$env:LOCALAPPDATA\WSL USB Manager\persistent_example.txt"
1771723785
```

Related to #35 