### PR TITLE
feat: persist auto attach profiles

### DIFF
--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -17,7 +17,7 @@ use crate::{
     win_utils,
 };
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum Profile {
     Device {
         hw_id: String,
@@ -26,6 +26,16 @@ pub enum Profile {
     Port {
         bus_id: String,
     },
+}
+
+// Devices can change description while being bound/unbound, don't include it in the hash
+impl Hash for Profile {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Profile::Device { hw_id, .. } => hw_id.hash(state),
+            Profile::Port { bus_id } => bus_id.hash(state),
+        }
+    }
 }
 
 #[derive(Default)]

--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -231,14 +231,10 @@ impl AutoAttacher {
             .unwrap()
             .profiles
             .iter_mut()
-            .map(|(profile, data)| {
-                data.update_process_status();
-
-                ProfileInfo {
-                    profile: profile.clone(),
-                    active: data.process.is_some(),
-                    last_error: data.last_error.clone(),
-                }
+            .map(|(profile, data)| ProfileInfo {
+                profile: profile.clone(),
+                active: data.process.is_some(),
+                last_error: data.last_error.clone(),
             })
             .collect()
     }
@@ -264,19 +260,25 @@ impl AutoAttacher {
                         .collect()
                 };
 
+                // Push the wake event handle as part of the handles to wait on, for manual wakeup
                 process_handles.push(win_utils::SendHandle(wake_raw as _));
 
                 let Some(wakeup_index) = win_utils::wait_for_handles(&process_handles) else {
                     continue;
                 };
 
-                // Only notify when a process handle was signaled, not the wake event
-                if wakeup_index < process_handles.len() - 1 {
-                    let notice = shared.lock().unwrap().ui_refresh_notice;
-                    if let Some(notice) = notice {
-                        notice.notice();
-                    }
+                // Return to waiting if the stop event was signaled
+                if wakeup_index == process_handles.len() - 1 {
+                    continue;
                 }
+
+                // Some process status changed, update the status
+                let mut state = shared.lock().unwrap();
+                state.profiles.values_mut().for_each(|data| {
+                    data.update_process_status();
+                });
+                // Notify the UI
+                state.ui_refresh_notice.inspect(|n| n.notice());
             }
         });
 

--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -116,6 +116,7 @@ impl AutoAttacher {
         }
 
         self.activate_profile(new_profile)
+            .inspect(|_| self.on_profiles_changed())
     }
 
     pub fn add_port(&mut self, device: &UsbDevice) -> Result<(), String> {
@@ -132,6 +133,7 @@ impl AutoAttacher {
         }
 
         self.activate_profile(new_profile)
+            .inspect(|_| self.on_profiles_changed())
     }
 
     pub fn activate_profile(&mut self, profile: Profile) -> Result<(), String> {
@@ -155,8 +157,6 @@ impl AutoAttacher {
         // If there was a process for this profile already, it will be killed automatically
         // when the old ProfileData is dropped, see Drop implementation of ProfileData
         self.profiles.insert(profile, insert_data);
-
-        self.watch_processes();
         Ok(())
     }
 
@@ -167,7 +167,7 @@ impl AutoAttacher {
 
         self.profiles.remove(profile);
 
-        self.watch_processes();
+        self.on_profiles_changed();
         Ok(())
     }
 
@@ -186,6 +186,10 @@ impl AutoAttacher {
             .collect()
     }
 
+    pub fn on_profiles_changed(&mut self) {
+        self.watch_processes();
+    }
+
     fn watch_processes(&mut self) {
         // Stop the already running watcher and spawn a new one with the updated list of processes
         if let Some(watcher) = self.process_watcher.take() {
@@ -194,6 +198,11 @@ impl AutoAttacher {
                 .thread
                 .join()
                 .expect("Failed to join process watcher thread");
+        }
+
+        // Skip running the watcher thread if there are no profiles
+        if self.profiles.is_empty() {
+            return;
         }
 
         let mut process_handles: Vec<win_utils::SendHandle> = self

--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -1,5 +1,11 @@
 use std::{
-    collections::HashMap, hash::Hash, io::Read, os::windows::io::AsRawHandle, thread::JoinHandle,
+    collections::HashMap,
+    fs::File,
+    hash::Hash,
+    io::{Read, Write},
+    os::windows::io::AsRawHandle,
+    path::{Path, PathBuf},
+    thread::JoinHandle,
 };
 
 use native_windows_gui as nwg;
@@ -94,6 +100,7 @@ pub struct AutoAttacher {
     profiles: HashMap<Profile, ProfileData>,
     process_watcher: Option<ProcessWatcher>,
     pub ui_refresh_notice: Option<nwg::NoticeSender>,
+    storage_path: Option<PathBuf>,
 }
 
 impl AutoAttacher {
@@ -120,33 +127,34 @@ impl AutoAttacher {
     }
 
     pub fn add_port(&mut self, device: &UsbDevice) -> Result<(), String> {
+        let bus_id = device
+            .bus_id
+            .as_ref()
+            .ok_or("The device does not have a bus ID.".to_string())?;
+
         let new_profile = Profile::Port {
-            bus_id: device
-                .bus_id
-                .as_ref()
-                .ok_or("The device does not have a bus ID.".to_string())?
-                .to_owned(),
+            bus_id: bus_id.clone(),
         };
 
         if self.profiles.contains_key(&new_profile) {
             return Err("The port is already in the auto attach list.".to_string());
         }
 
+        // Binds the device as a (wanted) side effect
+        usbipd::policy_add(bus_id)?;
+
+        // Cleanup the added policy if auto-attach fails
         self.activate_profile(new_profile)
             .inspect(|_| self.on_profiles_changed())
+            .inspect_err(|_| {
+                let _ = usbipd::policy_remove(bus_id);
+            })
     }
 
     pub fn activate_profile(&mut self, profile: Profile) -> Result<(), String> {
         let process = match &profile {
             Profile::Device { hw_id, .. } => usbipd::auto_attach_device(hw_id),
-            Profile::Port { bus_id } => {
-                // Binds the device as a (wanted) side effect
-                usbipd::policy_add(bus_id)?;
-                usbipd::auto_attach_port(bus_id).inspect_err(|_| {
-                    // Cleanup the added policy if auto-attach fails
-                    let _ = usbipd::policy_remove(bus_id);
-                })
-            }
+            Profile::Port { bus_id } => usbipd::auto_attach_port(bus_id),
         }?;
 
         let insert_data = ProfileData {
@@ -187,6 +195,7 @@ impl AutoAttacher {
     }
 
     pub fn on_profiles_changed(&mut self) {
+        self.persist_profiles();
         self.watch_processes();
     }
 
@@ -240,5 +249,53 @@ impl AutoAttacher {
             thread: watcher_thread,
             stop_event,
         });
+    }
+
+    pub fn with_storage(storage_path: &Path) -> Self {
+        let mut attacher = AutoAttacher {
+            storage_path: Some(storage_path.to_owned()),
+            ..Default::default()
+        };
+
+        let Ok(mut file) = File::open(storage_path) else {
+            return attacher;
+        };
+
+        let mut buf = Vec::new();
+        if file.read_to_end(&mut buf).is_err() {
+            return attacher;
+        }
+
+        let persisted_profiles: Vec<Profile> = match serde_json::from_slice(&buf) {
+            Ok(profiles) => profiles,
+            Err(_) => return attacher,
+        };
+
+        for profile in persisted_profiles {
+            let _ = attacher.activate_profile(profile);
+        }
+
+        attacher.watch_processes();
+        attacher
+    }
+
+    pub fn persist_profiles(&self) {
+        let Some(storage_path) = &self.storage_path else {
+            // Skip if no storage path was provided
+            return;
+        };
+
+        let profiles = self.profiles.keys().collect::<Vec<_>>();
+
+        let serialized = match serde_json::to_string_pretty(&profiles) {
+            Ok(json) => json,
+            Err(_) => return,
+        };
+
+        let Ok(mut file) = File::create(storage_path) else {
+            return;
+        };
+
+        let _ = file.write_all(serialized.as_bytes());
     }
 }

--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -5,6 +5,7 @@ use std::{
     io::{Read, Write},
     os::windows::io::AsRawHandle,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
     thread::JoinHandle,
 };
 
@@ -91,21 +92,34 @@ impl Drop for ProfileData {
 }
 
 struct ProcessWatcher {
+    #[allow(dead_code)]
     thread: JoinHandle<()>,
-    stop_event: win_utils::Event,
+    wake_event: win_utils::Event,
+}
+
+#[derive(Default)]
+struct SharedState {
+    profiles: HashMap<Profile, ProfileData>,
+    ui_refresh_notice: Option<nwg::NoticeSender>,
 }
 
 #[derive(Default)]
 pub struct AutoAttacher {
-    profiles: HashMap<Profile, ProfileData>,
+    shared: Arc<Mutex<SharedState>>,
     process_watcher: Option<ProcessWatcher>,
-    pub ui_refresh_notice: Option<nwg::NoticeSender>,
     storage_path: Option<PathBuf>,
 }
 
 impl AutoAttacher {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    pub fn set_ui_refresh_notice(&mut self, notice: Option<nwg::NoticeSender>) {
+        self.shared.lock().unwrap().ui_refresh_notice = notice;
+
+        // Start the watcher when the notice is set, no point starting it earlier
+        self.start_watcher();
     }
 
     pub fn add_device(&mut self, device: &UsbDevice) -> Result<(), String> {
@@ -118,12 +132,18 @@ impl AutoAttacher {
             description: device.description.clone(),
         };
 
-        if self.profiles.contains_key(&new_profile) {
+        if self
+            .shared
+            .lock()
+            .unwrap()
+            .profiles
+            .contains_key(&new_profile)
+        {
             return Err("The device is already in the auto attach list.".to_string());
         }
 
         self.activate_profile(new_profile)
-            .inspect(|_| self.on_profiles_changed())
+            .inspect(|_| self.persist_profiles())
     }
 
     pub fn add_port(&mut self, device: &UsbDevice) -> Result<(), String> {
@@ -136,7 +156,13 @@ impl AutoAttacher {
             bus_id: bus_id.clone(),
         };
 
-        if self.profiles.contains_key(&new_profile) {
+        if self
+            .shared
+            .lock()
+            .unwrap()
+            .profiles
+            .contains_key(&new_profile)
+        {
             return Err("The port is already in the auto attach list.".to_string());
         }
 
@@ -145,7 +171,7 @@ impl AutoAttacher {
 
         // Cleanup the added policy if auto-attach fails
         self.activate_profile(new_profile)
-            .inspect(|_| self.on_profiles_changed())
+            .inspect(|_| self.persist_profiles())
             .inspect_err(|_| {
                 let _ = usbipd::policy_remove(bus_id);
             })
@@ -164,7 +190,15 @@ impl AutoAttacher {
 
         // If there was a process for this profile already, it will be killed automatically
         // when the old ProfileData is dropped, see Drop implementation of ProfileData
-        self.profiles.insert(profile, insert_data);
+        self.shared
+            .lock()
+            .unwrap()
+            .profiles
+            .insert(profile, insert_data);
+
+        if let Some(watcher) = &self.process_watcher {
+            watcher.wake_event.set();
+        }
         Ok(())
     }
 
@@ -173,14 +207,17 @@ impl AutoAttacher {
             usbipd::policy_remove(bus_id)?;
         }
 
-        self.profiles.remove(profile);
+        self.shared.lock().unwrap().profiles.remove(profile);
 
-        self.on_profiles_changed();
+        self.persist_profiles();
         Ok(())
     }
 
     pub fn profiles(&mut self) -> Vec<ProfileInfo> {
-        self.profiles
+        self.shared
+            .lock()
+            .unwrap()
+            .profiles
             .iter_mut()
             .map(|(profile, data)| {
                 data.update_process_status();
@@ -194,60 +231,46 @@ impl AutoAttacher {
             .collect()
     }
 
-    pub fn on_profiles_changed(&mut self) {
-        self.persist_profiles();
-        self.watch_processes();
-    }
-
-    fn watch_processes(&mut self) {
-        // Stop the already running watcher and spawn a new one with the updated list of processes
-        if let Some(watcher) = self.process_watcher.take() {
-            watcher.stop_event.set();
-            watcher
-                .thread
-                .join()
-                .expect("Failed to join process watcher thread");
-        }
-
-        // Skip running the watcher thread if there are no profiles
-        if self.profiles.is_empty() {
-            return;
-        }
-
-        let mut process_handles: Vec<win_utils::SendHandle> = self
-            .profiles
-            .values()
-            .filter_map(|data| data.process.as_ref().map(|p| p.as_raw_handle()))
-            .collect::<Vec<_>>()
-            .into_iter()
-            .map(win_utils::SendHandle)
-            .collect();
-
-        // Add a stop event to the handle list so that the thread can be manually woken up
-        let stop_event = win_utils::Event::new();
-        process_handles.push(stop_event.as_raw_handle().into());
-
-        let refresh_notice = self.ui_refresh_notice;
+    fn start_watcher(&mut self) {
+        let wake_event = win_utils::Event::new();
+        let wake_raw = wake_event.as_raw_handle() as usize;
+        let shared = self.shared.clone();
 
         let watcher_thread = std::thread::spawn(move || {
-            let Some(wakeup_index) = win_utils::wait_for_handles(&process_handles) else {
-                // Wait failed, not a critical error
-                return;
-            };
-            let Some(notice) = refresh_notice else {
-                return;
-            };
+            loop {
+                let mut process_handles: Vec<win_utils::SendHandle> = {
+                    shared
+                        .lock()
+                        .unwrap()
+                        .profiles
+                        .values()
+                        .filter_map(|data| {
+                            data.process
+                                .as_ref()
+                                .map(|p| win_utils::SendHandle(p.as_raw_handle()))
+                        })
+                        .collect()
+                };
 
-            // If the stop event (last handle) was signaled, skip refreshing the UI since the UI
-            // thread is already refreshing the profiles as part of the user interaction
-            if wakeup_index < process_handles.len() - 1 {
-                notice.notice();
+                process_handles.push(win_utils::SendHandle(wake_raw as _));
+
+                let Some(wakeup_index) = win_utils::wait_for_handles(&process_handles) else {
+                    continue;
+                };
+
+                // Only notify when a process handle was signaled, not the wake event
+                if wakeup_index < process_handles.len() - 1 {
+                    let notice = shared.lock().unwrap().ui_refresh_notice;
+                    if let Some(notice) = notice {
+                        notice.notice();
+                    }
+                }
             }
         });
 
         self.process_watcher = Some(ProcessWatcher {
             thread: watcher_thread,
-            stop_event,
+            wake_event,
         });
     }
 
@@ -275,7 +298,6 @@ impl AutoAttacher {
             let _ = attacher.activate_profile(profile);
         }
 
-        attacher.watch_processes();
         attacher
     }
 
@@ -285,7 +307,8 @@ impl AutoAttacher {
             return;
         };
 
-        let profiles = self.profiles.keys().collect::<Vec<_>>();
+        let shared = self.shared.lock().unwrap();
+        let profiles = shared.profiles.keys().collect::<Vec<_>>();
 
         let serialized = match serde_json::to_string_pretty(&profiles) {
             Ok(json) => json,

--- a/src/auto_attacher.rs
+++ b/src/auto_attacher.rs
@@ -60,8 +60,10 @@ impl ProfileData {
         let Ok(Some(exit_status)) = process.try_wait() else {
             return;
         };
-        // Should not happen, ignore
+        // Process exited with no error (WSL was shut down), clear the process without error
         if exit_status.success() {
+            self.process = None;
+            self.last_error = Some("Process exited without error.".to_string());
             return;
         }
 

--- a/src/gui/auto_attach_tab/auto_attach_tab.rs
+++ b/src/gui/auto_attach_tab/auto_attach_tab.rs
@@ -205,6 +205,11 @@ impl GuiTab for AutoAttachTab {
         self.window.set(window.handle);
         self.init_list();
         self.refresh();
+
+        // Give the refresh notice to the auto attacher so that it can trigger UI refreshes
+        self.auto_attacher
+            .borrow_mut()
+            .set_ui_refresh_notice(Some(self.refresh_notice.sender()));
     }
 
     fn refresh(&self) {
@@ -225,9 +230,6 @@ impl PartialUi for AutoAttachTab {
         nwg::Notice::builder()
             .parent(parent_ref.unwrap())
             .build(&mut data.refresh_notice)?;
-
-        // Give the refresh notice to the auto attacher so that it can trigger UI refreshes
-        data.auto_attacher.borrow_mut().ui_refresh_notice = Some(data.refresh_notice.sender());
 
         nwg::ListView::builder()
             .list_style(nwg::ListViewStyle::Detailed)

--- a/src/gui/connected_tab/connected_tab.rs
+++ b/src/gui/connected_tab/connected_tab.rs
@@ -37,6 +37,9 @@ pub struct ConnectedTab {
 
     window: RefCell<Rc<nwg::Window>>,
 
+    /// A notice to refresh the connected tab
+    refresh_notice: nwg::Notice,
+
     /// A notice sender to notify the auto attach tab to refresh
     pub auto_attach_notice: Cell<Option<nwg::NoticeSender>>,
 
@@ -273,7 +276,8 @@ impl ConnectedTab {
         // Prepare closure access to parent data
         let parent_window = Rc::downgrade(&self.window.borrow());
         let child_ui = Rc::downgrade(&ui.inner);
-        let notice = self.auto_attach_notice.get();
+        let connected_tab_notice = self.refresh_notice.sender();
+        let auto_attach_notice = self.auto_attach_notice.get();
 
         let parent_handler =
             nwg::full_bind_event_handler(&ui.window.handle, move |evt, _evt_data, handle| {
@@ -287,7 +291,8 @@ impl ConnectedTab {
 
                 if evt == nwg::Event::OnWindowClose && handle == ui.window.handle {
                     parent_window.set_enabled(true);
-                    if let Some(n) = notice {
+                    connected_tab_notice.notice();
+                    if let Some(n) = auto_attach_notice {
                         n.notice();
                     }
                 }
@@ -401,6 +406,10 @@ impl PartialUi for ConnectedTab {
             .ex_flags(nwg::ListViewExFlags::FULL_ROW_SELECT)
             .parent(parent_ref.unwrap())
             .build(&mut data.list_view)?;
+
+        nwg::Notice::builder()
+            .parent(parent_ref.unwrap())
+            .build(&mut data.refresh_notice)?;
 
         nwg::Frame::builder()
             .parent(parent_ref.unwrap())
@@ -535,6 +544,11 @@ impl PartialUi for ConnectedTab {
             nwg::Event::OnWindowClose => {
                 if handle == self.device_info_frame.handle {
                     ConnectedTab::inhibit_close(evt_data);
+                }
+            }
+            nwg::Event::OnNotice => {
+                if handle == self.refresh_notice.handle {
+                    ConnectedTab::refresh(self);
                 }
             }
             nwg::Event::OnButtonClick => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod gui;
 mod usbipd;
 mod win_utils;
 
-use std::{cell::RefCell, process::ExitCode, rc::Rc};
+use std::{cell::RefCell, path::PathBuf, process::ExitCode, rc::Rc};
 
 use args::Args;
 use auto_attacher::AutoAttacher;
@@ -45,9 +45,21 @@ fn main() -> ExitCode {
         }
     }
 
-    let auto_attacher = Rc::new(RefCell::new(AutoAttacher::new()));
+    let storage_path =
+        match std::env::var("LOCALAPPDATA").map(|dir| PathBuf::from(dir).join("WSL USB Manager")) {
+            Ok(path) => std::fs::create_dir_all(&path).map(|_| path).ok(),
+            Err(_) => None,
+        };
 
-    let start = gui::start(&auto_attacher, args.minimized);
+    let auto_attacher = if let Some(mut path) = storage_path {
+        path.push("profiles.json");
+        AutoAttacher::with_storage(&path)
+    } else {
+        AutoAttacher::new()
+    };
+    let auto_attacher_rc = Rc::new(RefCell::new(auto_attacher));
+
+    let start = gui::start(&auto_attacher_rc, args.minimized);
 
     if let Err(err) = start {
         gui::show_start_failure(&err.to_string());


### PR DESCRIPTION
This PR introduces persistent auto attach profiles across app restarts. Profiles are loaded at startup and an attempt to attach the devices is made.
The app will not retry to auto attach if an error occurs, as the number of failure causes would be too high to handle. An exception will be made in the case of WSL not being started yet, although in a future PR.

Additional minor fixes were made to the auto attach code, including race conditions, deadlocks and some minor performance optimizations (mainly because of moving stuff off the UI thread).

Closes #20.